### PR TITLE
Add support for Laravel 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CachedEmbed
-A package for Laravel 5.5+ and Laravel 6.x to cache embed information retrieved using the https://github.com/oscarotero/Embed package.
+A package for Laravel 5.5+, Laravel 6.x and Laravel 7.x to cache embed information retrieved using the https://github.com/oscarotero/Embed package.
 
 [![Buy us a tree](https://img.shields.io/badge/Treeware-%F0%9F%8C%B3-lightgreen?style=for-the-badge)](https://offset.earth/ademtisoftware?gift-trees)
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Laravel package to cache embed information from https://github.com/oscarotero/Embed. Works with Laravel 5.5 to 5.8",
     "keywords": [
         "Laravel",
-	"oembed",
+        "oembed",
         "embed",
         "cache"
     ],
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.0",
         "embed/embed": "~3.3",
-        "illuminate/cache": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|~6.0"
+        "illuminate/cache": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds support for Laravel 7.x and updates the readme.

It might also be a good idea to update the repository description, since it only mentions Laravel 5.5.